### PR TITLE
strip www and ensure twitter handles start with @

### DIFF
--- a/db/migrations/20201118172557_strip-www-and-ensure-@.js
+++ b/db/migrations/20201118172557_strip-www-and-ensure-@.js
@@ -1,0 +1,29 @@
+exports.up = function(knex) {
+
+  // Delete any websites with domains such as www.xyz.com if we already have xyz.com
+  await knex.raw(`
+    DELETE
+      FROM websites
+     WHERE id in (
+       SELECT w1.id
+        FROM websites as w1
+        JOIN websites as w2 ON replace(w1.domain, 'www.', '') = w2.domain
+       WHERE (lower(w1.domain) LIKE 'www.%')
+     )
+  `)
+
+  // Eliminate 'www.' in all domains
+  await knex.raw(`
+    UPDATE websites
+       SET domain = replace(domain, 'www.', '')
+     WHERE (lower(domain) LIKE 'www.%')
+  `)
+
+  // Add a '@' at the start of all twitter handles that do not have them
+  await knex.raw(`
+    UPDATE websites
+       SET twitter_handle = CONCAT('@', twitter_handle)
+     WHERE twitter_handle IS NOT NULL
+       AND twitter_handle NOT LIKE '@%'
+  `)
+}

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -10,12 +10,12 @@ const readFile = promisify(fsReadFile)
 type SaveFeedbackParam = {
   user: SerializedUser,
   status: string,
-  host: string,
+  domain: string,
   imagesData: ReadonlyArray<FeedbackImageData>,
   url: string
 }
 
-const saveFeedback = async ({ user, status, host, imagesData, url }: SaveFeedbackParam) => {
+const saveFeedback = async ({ user, status, domain, imagesData, url }: SaveFeedbackParam) => {
   const insertFeedbackSql = `
 WITH inserted_website(id) as (
   INSERT INTO websites(domain)
@@ -35,7 +35,7 @@ INSERT INTO feedback_images (feedback_id, name, file, file_extension)
     }
 `
 
-  const defaultQueryArgs: ReadonlyArray<any> = [host, user.id, status, url]
+  const defaultQueryArgs: ReadonlyArray<any> = [domain, user.id, status, url]
   const imagesQueryArgs = flatten(imagesData.map(imageData => [imageData.name, imageData.file, imageData.file_extension]))
   const queryArgs = defaultQueryArgs.concat(imagesQueryArgs)
   // tslint:disable-next-line: no-expression-statement

--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -15,5 +15,8 @@ async function getHtml(domain: string): Promise<string> {
 
 export async function getTwitterHandle(domain: string): Promise<null | string> {
   const $ = cheerio.load(await getHtml(domain))
-  return $('meta[name="twitter:site"]').attr('content') || $('meta[name="twitter:creator"]').attr('content') || null
+  const twitterHandle = $('meta[name="twitter:site"]').attr('content') || $('meta[name="twitter:creator"]').attr('content')
+  if (!twitterHandle) return null
+  if (twitterHandle.startsWith('@')) return twitterHandle
+  return `@${twitterHandle}`
 }

--- a/src/websites.ts
+++ b/src/websites.ts
@@ -1,0 +1,15 @@
+import db from './db'
+const upsert = require('knex-upsert')
+
+
+export function upsertWebsite(object: { domain: string, twitter_handle: null | string }): Promise<Website> {
+  if (object.domain.startsWith('www.')) {
+    throw new Error('Strip www. before creating the website')
+  }
+
+  if (object.twitter_handle && !object.twitter_handle.startsWith('@')) {
+    throw new Error('Twitter handle must start with a @')
+  }
+
+  return upsert({ db, table: 'websites', object, key: 'domain' })
+}


### PR DESCRIPTION
Fixes https://github.com/morehumaninternet/roar-extension/issues/62

The issue was that we were able to pull the twitter handle from espn.com, but it was not prefixed with a '@' symbol, which roar requires. Now we explicitly check for whether the handle starts with '@' and insert one if it does not. 

While we're at it, I observed a mish-mash where several websites were added twice, because we don't check for `www` so we always strip that at the start of websites as well and get rid of duplicative websites.

<img width="640" alt="Screen Shot 2020-11-18 at 5 52 07 PM" src="https://user-images.githubusercontent.com/6589960/99598124-0f7ccd00-29c7-11eb-9491-f9d00979ae80.png">
<img width="438" alt="Screen Shot 2020-11-18 at 5 52 40 PM" src="https://user-images.githubusercontent.com/6589960/99598127-11df2700-29c7-11eb-9104-4e17c96123bc.png">
