### PR TITLE
prevent 401 rewrite to 204 by including response body

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -50,7 +50,7 @@ const domainOf = (url: string): string => {
 function getCurrentUser(ctx: IRouterContext): SerializedUser {
   const user: Maybe<SerializedUser> = ctx.session?.passport?.user
   if (!user) {
-    throw { status: 401 }
+    throw { status: 401, message: 'Unauthorized' }
   }
   return user
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -156,5 +156,5 @@ export const postFeedback = async (ctx: IRouterContext): Promise<any> => {
 
 export async function logout(ctx: IRouterContext): Promise<any> {
   ctx.session = null // tslint:disable-line: no-expression-statement
-  return Object.assign(ctx.response, { status: 200 })
+  return Object.assign(ctx.response, { status: 200, body: { loggedOut: true } })
 }


### PR DESCRIPTION
See https://github.com/morehumaninternet/roar-server/blob/3c89ed88fd31a9afea916b38371561c92c711a9f/src/errorHandling.ts#L20

By not including a `message` koa will not write a response body and in turn will rewrite the status code as 204. This prevents that.