### PR TITLE
Fixed a typo in @face-font url path

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -17,21 +17,21 @@ body {
   font-style: normal;
   font-weight: 400;
   src: local("Roboto Regular"), local("Roboto-Regular"),
-    url("../Roboto-Regular.ttf");
+    url("./Roboto-Regular.ttf");
 }
 
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("../Roboto-Bold.ttf");
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./Roboto-Bold.ttf");
 }
 
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 300;
-  src: local("Roboto Light"), local("Roboto-Light"), url("../Roboto-Light.ttf");
+  src: local("Roboto Light"), local("Roboto-Light"), url("./Roboto-Light.ttf");
 }
 
 header {

--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -17,21 +17,21 @@ body {
   font-style: normal;
   font-weight: 400;
   src: local("Roboto Regular"), local("Roboto-Regular"),
-    url("./Roboto-Regular.ttf");
+    url("Roboto-Regular.ttf");
 }
 
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./Roboto-Bold.ttf");
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("Roboto-Bold.ttf");
 }
 
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 300;
-  src: local("Roboto Light"), local("Roboto-Light"), url("./Roboto-Light.ttf");
+  src: local("Roboto Light"), local("Roboto-Light"), url("Roboto-Light.ttf");
 }
 
 header {


### PR DESCRIPTION
The typo in the url affect the landing page default Roboto font. Tested on local, issue fixed. 
![Screen Shot 2021-01-05 at 12 19 22 PM](https://user-images.githubusercontent.com/16155615/103687761-ce348280-4f5e-11eb-854c-5979fbbe18f6.png)
. 